### PR TITLE
Remove opencv_face library requirement from Linux build.

### DIFF
--- a/Sharedfiles/opencv.pri
+++ b/Sharedfiles/opencv.pri
@@ -52,8 +52,7 @@ win32 {
             -lopencv_highgui \
             -lopencv_imgproc \
             -lopencv_videoio \
-            -lopencv_imgcodecs \
-            -lopencv_face
+            -lopencv_imgcodecs
 }
 
 DEFINES += OPENCV_DIR=\\\"$${OPENCV_DIR}\\\"


### PR DESCRIPTION
Windows build doesn't seem to require it.
Default build of opencv 3.2.0 does not contain the library.